### PR TITLE
Google AdSenseの広告がめっちゃでかいのを修正

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -26,7 +26,7 @@ function googleAdsense(
 			client={client}
 			slot={slot}
 			style={{ display: 'block' }}
-			format='auto'
+			format='horizontal'
 			responsive='true'
 		/>
 	</div>);


### PR DESCRIPTION
### 変更点

- 横長な広告を優先して使うようにした

### 備考

モバイル環境にて、サイト構成によっては`format='horizontal'`を指定しても効かないこともあるとのこと。
その場合は`responsive='false'`にして、レスポンシブデザインな広告を諦める必要があるとのこと。

### 参考

- <https://support.google.com/adsense/answer/9183460?hl=ja#zippy=%2C%E6%A8%AA%E9%95%B7%E3%81%AE%E5%BD%A2%E7%8A%B6%E3%82%92%E6%8C%87%E5%AE%9A%E3%81%99%E3%82%8B%E5%A0%B4%E5%90%88>